### PR TITLE
Prepare assets_for_android_views for Dart 3.0

### DIFF
--- a/dev/integration_tests/assets_for_android_views/pubspec.yaml
+++ b/dev/integration_tests/assets_for_android_views/pubspec.yaml
@@ -1,10 +1,10 @@
 name: assets_for_android_views
 description: Recorded touch event sequences
-version : 0.1.0
+version : 0.2.0
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: http://flutter.io
 environment:
-  sdk: '>=1.19.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
   flutter: '>=0.1.0 <2.0.0'
 
 flutter:


### PR DESCRIPTION
The lower bound of assets_for_android_views was below `2.12` which opts out of null safety. This has been fixed to prepare the package for Dart 3.0.